### PR TITLE
Remove queries from http template

### DIFF
--- a/templates/actions/http.json.tpl
+++ b/templates/actions/http.json.tpl
@@ -5,7 +5,6 @@
     "uri": "${uri}",
     "method": "${method}",
     "headers": ${headers},
-    "queries": {},
     "body": ${body}
   }
 }


### PR DESCRIPTION
* Providing an empty `queries` parameter in the http action, drops all queries provided in the URI