### PR TITLE
Fix Teams URI queries

### DIFF
--- a/templates/actions/http.json.tpl
+++ b/templates/actions/http.json.tpl
@@ -5,7 +5,7 @@
     "uri": "${uri}",
     "method": "${method}",
     "headers": ${headers},
-    "queries": {},
+    "queries": ${queries},
     "body": ${body}
   }
 }


### PR DESCRIPTION
* The Teams URI contains query strings, which when provided directly to the `uri` parameter, are dropped when the Logic App makes the request
* To fix this, we can extract the query strings, and pass them to the `queries` parameter instead